### PR TITLE
Confirm explicit flush() is not needed

### DIFF
--- a/bluesky_kafka/tests/test_kafka.py
+++ b/bluesky_kafka/tests/test_kafka.py
@@ -121,7 +121,6 @@ def test_kafka(RE, hw, bootstrap_servers, serializer, deserializer, auto_offset_
         serializer=serializer,
     )
     RE.subscribe(kafka_publisher)
-    time.sleep(10)
 
     # COMPONENT 3
     # Run a RemoteDispatcher on a separate process. Pass the documents

--- a/bluesky_kafka/tests/test_kafka.py
+++ b/bluesky_kafka/tests/test_kafka.py
@@ -170,8 +170,6 @@ def test_kafka(RE, hw, bootstrap_servers, serializer, deserializer, auto_offset_
     RE.subscribe(local_cb)
     RE(count([hw.det]), md=md)
     time.sleep(10)
-    kafka_publisher.flush()
-    time.sleep(10)
 
     # Get the documents from the queue (or timeout --- test will fail)
     remote_published_documents = []

--- a/bluesky_kafka/tests/test_kafka.py
+++ b/bluesky_kafka/tests/test_kafka.py
@@ -116,6 +116,7 @@ def test_kafka(RE, hw, bootstrap_servers, serializer, deserializer, auto_offset_
             "acks": 1,
             "enable.idempotence": False,
             "request.timeout.ms": 5000,
+            "linger.ms": 1000,
         },
         serializer=serializer,
     )

--- a/bluesky_kafka/tests/test_kafka.py
+++ b/bluesky_kafka/tests/test_kafka.py
@@ -152,7 +152,7 @@ def test_kafka(RE, hw, bootstrap_servers, serializer, deserializer, auto_offset_
         target=make_and_start_dispatcher, daemon=True, args=(queue_,)
     )
     dispatcher_proc.start()
-    time.sleep(10)  # As above, give this plenty of time to start.
+    time.sleep(10)
 
     local_published_documents = []
 

--- a/bluesky_kafka/tests/test_kafka.py
+++ b/bluesky_kafka/tests/test_kafka.py
@@ -22,6 +22,8 @@ from bluesky.plans import count
 from event_model import sanitize_doc
 
 
+# the Kafka test broker should be configured with
+# KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
 TEST_TOPIC = "bluesky-kafka-test"
 
 
@@ -101,6 +103,7 @@ def test_kafka(RE, hw, bootstrap_servers, serializer, deserializer, auto_offset_
     # COMPONENT 1
     # a Kafka broker must be running
     # in addition the broker must have topic "bluesky-kafka-test"
+    # or be configured to create topics on demand
 
     # COMPONENT 2
     # Run a Publisher and a RunEngine in this process


### PR DESCRIPTION
This PR removes an explicit `flush()` from the tests, since it should not be needed.

Configuring Kafka Producers with `linger.ms=0` should give similar results to calling `flush()` explicitly. Testing shows this is not strictly necessary, either.