### PR TITLE
flush producers on each stop document

### DIFF
--- a/bluesky_kafka/__init__.py
+++ b/bluesky_kafka/__init__.py
@@ -68,12 +68,15 @@ class Publisher:
     topic: str
         Topic to which all messages will be published.
     bootstrap_servers: str
-        Comma-delimited list of Kafka server addresses as a string such as ``'127.0.0.1:9092'``
+        Comma-delimited list of Kafka server addresses as a string such as ``'127.0.0.1:9092'``.
     key: str
         Kafka "key" string. Specify a key to maintain message order. If None is specified
         no ordering will be imposed on messages.
     producer_config: dict, optional
-        Dictionary configuration information used to construct the underlying Kafka Producer
+        Dictionary configuration information used to construct the underlying Kafka Producer.
+    flush_on_stop_doc: bool, optional
+        False by default, set to True to flush() the underlying Kafka Producer when a stop
+        document is received.
     serializer: function, optional
         Function to serialize data. Default is pickle.dumps.
 
@@ -97,6 +100,7 @@ class Publisher:
         bootstrap_servers,
         key,
         producer_config=None,
+        flush_on_stop_doc=False,
         serializer=pickle.dumps,
     ):
         self._topic = topic
@@ -116,6 +120,7 @@ class Publisher:
 
         logger.info("producer configuration: %s", self._producer_config)
 
+        self._flush_on_stop_doc = flush_on_stop_doc
         self._producer = Producer(self._producer_config)
         self._serializer = serializer
 
@@ -152,7 +157,7 @@ class Publisher:
             value=self._serializer((name, doc)),
             callback=delivery_report,
         )
-        if name == "stop":
+        if name == "stop" and self._flush_on_stop_doc:
             self.flush()
 
     def flush(self):

--- a/bluesky_kafka/tests/test_kafka.py
+++ b/bluesky_kafka/tests/test_kafka.py
@@ -116,7 +116,6 @@ def test_kafka(RE, hw, bootstrap_servers, serializer, deserializer, auto_offset_
             "acks": 1,
             "enable.idempotence": False,
             "request.timeout.ms": 5000,
-            "linger.ms": 1000,
         },
         serializer=serializer,
     )


### PR DESCRIPTION
Testing has shown messages from short runs may not be published to brokers until some time after a run completes. This PR flushes a producer after a stop document is received to guarantee messages are published _at the latest_ when the run completes.

It may be we will find a better way to accomplish the same thing. Until then I would like to use this method.