### PR TITLE
add timeout to get_cluster_metadata and list_topics

### DIFF
--- a/bluesky_kafka/tests/test_utils.py
+++ b/bluesky_kafka/tests/test_utils.py
@@ -2,8 +2,36 @@ import re
 
 import pytest
 
+from confluent_kafka.cimpl import KafkaException
+
 from bluesky_kafka import BlueskyKafkaException
-from bluesky_kafka.utils import create_topics, delete_topics, list_topics
+from bluesky_kafka.utils import get_cluster_metadata, create_topics, delete_topics, list_topics
+
+
+def test_get_cluster_metadata_no_broker():
+    """
+    Test the default 10s timeout for get_cluster_metadata().
+
+    The default behavior for confluent_kakfa.Producer.list_topics() is no timeout,
+    which means it will hang forever if no connection can be made to a broker.
+    """
+    with pytest.raises(KafkaException):
+        get_cluster_metadata(
+            bootstrap_servers="1.1.1.1:9092"
+        )
+
+
+def test_list_topics_no_broker():
+    """
+    Test the default 10s timeout for list_topics().
+
+    The default behavior for confluent_kakfa.Producer.list_topics() is no timeout,
+    which means it will hang forever if no connection can be made to a broker.
+    """
+    with pytest.raises(KafkaException):
+        list_topics(
+            bootstrap_servers="1.1.1.1:9092"
+        )
 
 
 def test_create_topics(kafka_bootstrap_servers):

--- a/bluesky_kafka/utils.py
+++ b/bluesky_kafka/utils.py
@@ -11,7 +11,7 @@ from bluesky_kafka import BlueskyKafkaException
 log = logging.getLogger("bluesky.kafka")
 
 
-def get_cluster_metadata(bootstrap_servers):
+def get_cluster_metadata(bootstrap_servers, timeout=10):
     """
     Return cluster metadata for the cluster specified by bootstrap_servers.
 
@@ -19,17 +19,19 @@ def get_cluster_metadata(bootstrap_servers):
     ----------
     bootstrap_servers: str
         comma-delimited string of Kafka broker host:port, for example "localhost:9092"
+    timeout: float
+        maximum time to wait for a connection to a Kafka broker, 10s by default
 
     Returns
     -------
         confluent_kafka.admin.ClusterMetadata
     """
     kafka_producer = Producer({"bootstrap.servers": bootstrap_servers})
-    cluster_metadata = kafka_producer.list_topics()
+    cluster_metadata = kafka_producer.list_topics(timeout=timeout)
     return cluster_metadata
 
 
-def list_topics(bootstrap_servers):
+def list_topics(bootstrap_servers, timeout=10):
     """
     Return the topics dictionary from cluster metadata.
 
@@ -37,12 +39,14 @@ def list_topics(bootstrap_servers):
     ----------
     bootstrap_servers: str
         comma-delimited string of Kafka broker host:port, for example "localhost:9092"
-
+    timeout: float
+        maximum time to wait for a connection to a Kafka broker, 10s by default
+    
     Returns
     -------
         dictionary of topic name -> TopicMetadata
     """
-    cluster_metadata = get_cluster_metadata(bootstrap_servers)
+    cluster_metadata = get_cluster_metadata(bootstrap_servers, timeout=timeout)
     return cluster_metadata.topics
 
 


### PR DESCRIPTION
This PR adds a `timeout` parameter to `get_cluster_metadata` and `list_topics`.

Adding timeout parameters makes it possible to override the default behavior of the underlying confluent_kafka.Producer which is no timeout.