### PR TITLE
Adapt code from nslsii for publishing messages from a thread

### DIFF
--- a/bluesky_kafka/tests/conftest.py
+++ b/bluesky_kafka/tests/conftest.py
@@ -73,17 +73,11 @@ def temporary_topics(kafka_bootstrap_servers):
             # this will delete any un-consumed messages
             # the intention is to make tests repeatable by ensuring
             # they always start with a topics having no "old" messages
-            delete_topics(
-                bootstrap_servers=bootstrap_servers, topics_to_delete=topics
-            )
-            create_topics(
-                bootstrap_servers=bootstrap_servers, topics_to_create=topics
-            )
+            delete_topics(bootstrap_servers=bootstrap_servers, topics_to_delete=topics)
+            create_topics(bootstrap_servers=bootstrap_servers, topics_to_create=topics)
             yield topics
         finally:
-            delete_topics(
-                bootstrap_servers=bootstrap_servers, topics_to_delete=topics
-            )
+            delete_topics(bootstrap_servers=bootstrap_servers, topics_to_delete=topics)
 
     return _temporary_topics
 
@@ -115,11 +109,7 @@ def publisher_factory(kafka_bootstrap_servers):
     """
 
     def _publisher_factory(
-        topic,
-        bootstrap_servers=None,
-        key=None,
-        producer_config=None,
-        **kwargs,
+        topic, bootstrap_servers=None, key=None, producer_config=None, **kwargs,
     ):
         """
         Parameters

--- a/bluesky_kafka/tests/conftest.py
+++ b/bluesky_kafka/tests/conftest.py
@@ -1,6 +1,7 @@
-from contextlib import contextmanager
 import os
 import tempfile
+
+from contextlib import contextmanager
 
 import intake
 import numpy as np
@@ -10,7 +11,7 @@ import yaml
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
 
-from bluesky_kafka import Publisher
+from bluesky_kafka import BlueskyConsumer, Publisher
 from bluesky_kafka.utils import create_topics, delete_topics
 
 
@@ -154,6 +155,83 @@ def publisher_factory(kafka_bootstrap_servers):
         )
 
     return _publisher_factory
+
+
+@pytest.fixture(scope="function")
+def consume_documents_from_kafka_until_first_stop_document(kafka_bootstrap_servers):
+    """Use this fixture to consume Kafka messages containing bluesky (name, document) tuples.
+
+    This fixture will construct a BlueskyConsumer and run its polling loop. When the first
+    stop document is encountered the consumer polling loop will terminate so the test function
+    can continue.
+
+    Parameters
+    ----------
+    kafka_bootstrap_servers : pytest fixture
+        comma-delimited str of Kafka bootstrap server host:port specified on the pytest command line
+
+    Returns
+    -------
+    _consume_documents_from_kafka: function
+        calling this function will consume Kafka messages and place the (name, document)
+        tuples into a list; when the first stop document is encountered the consumer
+        polling loop terminates so the test can proceed
+    """
+
+    def _consume_documents_from_kafka(kafka_topic, bootstrap_servers=None):
+        if bootstrap_servers is None:
+            bootstrap_servers = kafka_bootstrap_servers
+
+        consumed_bluesky_documents = []
+
+        def store_consumed_document(consumer, topic, name, document):
+            """
+            This function keeps a list of all documents the consumer
+            gets from the Kafka broker(s).
+
+            Parameters
+            ----------
+            consumer: bluesky_kafka.BlueskyConsumer
+                unused
+            topic: str
+                unused
+            name: str
+                bluesky document name, such as "start", "descriptor", "event", etc
+            document: dict
+                dictionary of bluesky document data
+            """
+            consumed_bluesky_documents.append((name, document))
+
+        bluesky_consumer = BlueskyConsumer(
+            topics=[kafka_topic],
+            bootstrap_servers=bootstrap_servers,
+            group_id=f"{kafka_topic}.consumer.group",
+            consumer_config={
+                # this consumer is intended to read messages that
+                # have already been published, so it is necessary
+                # to specify "earliest" here
+                "auto.offset.reset": "earliest",
+            },
+            process_document=store_consumed_document,
+            polling_duration=1.0,
+        )
+
+        def until_first_stop_document():
+            """
+            This function returns False to end the BlueskyConsumer polling loop after seeing
+            a "stop" document. Without something like this the polling loop will never end.
+            """
+            if "stop" in [name for name, _ in consumed_bluesky_documents]:
+                return False
+            else:
+                return True
+
+        # start() will return when 'until_first_stop_document' returns False
+        bluesky_consumer.start(continue_polling=until_first_stop_document,)
+
+        return consumed_bluesky_documents
+
+    return _consume_documents_from_kafka
 
 
 @pytest.fixture(scope="function")

--- a/bluesky_kafka/tests/test_in_single_process.py
+++ b/bluesky_kafka/tests/test_in_single_process.py
@@ -1,3 +1,25 @@
+"""
+    Most bluesky-kafka tests require a Kafka broker.
+
+    Start Kafka and Zookeeper like this:
+      $ sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up
+    Remove Kafka and Zookeeper containers like this:
+      $ sudo docker ps -a -q
+      78485383ca6f
+      8a80fb4a385f
+      $ sudo docker stop 78485383ca6f 8a80fb4a385f
+      78485383ca6f
+      8a80fb4a385f
+      $ sudo docker rm 78485383ca6f 8a80fb4a385f
+      78485383ca6f
+      8a80fb4a385f
+    Or remove ALL containers like this:
+      $ sudo docker stop $(sudo docker ps -a -q)
+      $ sudo docker rm $(sudo docker ps -a -q)
+    Use this in difficult cases to remove *all traces* of docker containers:
+      $ sudo docker system prune -a
+"""
+
 import logging
 import pickle
 

--- a/bluesky_kafka/tests/test_in_single_process.py
+++ b/bluesky_kafka/tests/test_in_single_process.py
@@ -2,7 +2,9 @@
     Most bluesky-kafka tests require a Kafka broker.
 
     Start Kafka and Zookeeper like this:
-      $ sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up
+      $ cd scripts
+      $ bash start_kafka.sh
+    Stop Kafka and Zookeeper with Ctrl-C.
     Remove Kafka and Zookeeper containers like this:
       $ sudo docker ps -a -q
       78485383ca6f
@@ -19,8 +21,6 @@
     Use this in difficult cases to remove *all traces* of docker containers:
       $ sudo docker system prune -a
 """
-
-import logging
 import pickle
 
 import msgpack
@@ -34,15 +34,18 @@ from event_model import sanitize_doc
 from bluesky_kafka import Publisher, BlueskyConsumer, RemoteDispatcher
 
 
-test_log = logging.getLogger("bluesky.kafka.test")
-
-
 @pytest.mark.parametrize(
     "serializer, deserializer",
     [(pickle.dumps, pickle.loads), (msgpack.packb, msgpack.unpackb)],
 )
 def test_publisher_and_consumer(
-    kafka_bootstrap_servers, temporary_topics, publisher_factory, hw, serializer, deserializer
+    kafka_bootstrap_servers,
+    temporary_topics,
+    publisher_factory,
+    consume_documents_from_kafka_until_first_stop_document,
+    hw,
+    serializer,
+    deserializer,
 ):
     """Test publishing and consuming bluesky documents in Kafka messages.
 
@@ -72,7 +75,7 @@ def test_publisher_and_consumer(
             topic=topic,
             key=f"{topic}.key",
             flush_on_stop_doc=True,
-            serializer=serializer
+            serializer=serializer,
         )
 
         published_bluesky_documents = []
@@ -100,47 +103,9 @@ def test_publisher_and_consumer(
         # documents: start, descriptor, event, stop
         assert len(published_bluesky_documents) == 4
 
-        consumed_bluesky_documents = []
-
-        # this function stores all documents bluesky_consumer
-        # gets from the Kafka broker in a list
-        def store_consumed_document(consumer, topic, name, document):
-            consumed_bluesky_documents.append((name, document))
-
-        bluesky_consumer = BlueskyConsumer(
-            topics=[topic],
-            bootstrap_servers=kafka_bootstrap_servers,
-            group_id=f"{topic}.consumer.group",
-            consumer_config={
-                # it is important to set a short time interval
-                # for automatic commits or the Kafka broker may
-                # not be notified by the consumer that messages
-                # were received before the test ends; the result
-                # is that the Kafka broker will try to re-deliver
-                # those messages to the next consumer that subscribes
-                # to the same topic(s)
-                "auto.commit.interval.ms": 100,
-                # this consumer is intended to read messages that
-                # have already been published, so it is necessary
-                # to specify "earliest" here
-                "auto.offset.reset": "earliest",
-            },
-            process_document=store_consumed_document,
-            polling_duration=1.0,
-            deserializer=deserializer,
-        )
-
-        # this function returns False to end the bluesky_consumer polling loop
-        def until_first_stop_document():
-            assert len(consumed_bluesky_documents) <= len(published_bluesky_documents)
-            if "stop" in [name for name, _ in consumed_bluesky_documents]:
-                return False
-            else:
-                return True
-
-        # start() will return when 'until_first_stop_document' returns False
-        bluesky_consumer.start(
-            continue_polling=until_first_stop_document,
+        # retrieve the documents published as Kafka messages
+        consumed_bluesky_documents = consume_documents_from_kafka_until_first_stop_document(
+            kafka_topic=topic, deserializer=deserializer
         )
 
         assert len(published_bluesky_documents) == len(consumed_bluesky_documents)
@@ -168,7 +133,12 @@ def test_publisher_and_consumer(
     [(pickle.dumps, pickle.loads), (msgpack.packb, msgpack.unpackb)],
 )
 def test_publisher_and_remote_dispatcher(
-    kafka_bootstrap_servers, temporary_topics, publisher_factory, hw, serializer, deserializer
+    kafka_bootstrap_servers,
+    temporary_topics,
+    publisher_factory,
+    hw,
+    serializer,
+    deserializer,
 ):
     """Test publishing and dispatching bluesky documents in Kafka messages.
 
@@ -198,7 +168,7 @@ def test_publisher_and_remote_dispatcher(
             topic=topic,
             key=f"{topic}.key",
             flush_on_stop_doc=True,
-            serializer=serializer
+            serializer=serializer,
         )
 
         published_bluesky_documents = []
@@ -231,14 +201,6 @@ def test_publisher_and_remote_dispatcher(
             bootstrap_servers=kafka_bootstrap_servers,
             group_id=f"{topic}.consumer.group",
             consumer_config={
-                # it is important to set a short time interval
-                # for automatic commits or the Kafka broker may
-                # not be notified by the consumer that messages
-                # were received before the test ends; the result
-                # is that the Kafka broker will try to re-deliver
-                # those messages to the next consumer that subscribes
-                # to the same topic(s)
-                "auto.commit.interval.ms": 100,
                 # this consumer is intended to read messages that
                 # have already been published, so it is necessary
                 # to specify "earliest" here
@@ -266,9 +228,7 @@ def test_publisher_and_remote_dispatcher(
                 return True
 
         # start() will return when 'until_first_stop_document' returns False
-        remote_dispatcher.start(
-            continue_polling=until_first_stop_document,
-        )
+        remote_dispatcher.start(continue_polling=until_first_stop_document,)
 
         assert len(published_bluesky_documents) == len(dispatched_bluesky_documents)
 

--- a/bluesky_kafka/tests/test_queue_thread.py
+++ b/bluesky_kafka/tests/test_queue_thread.py
@@ -1,0 +1,265 @@
+import logging
+import re
+import queue
+import threading
+import time as ttime
+import uuid
+
+from unittest.mock import Mock
+
+from bluesky.plans import count
+from event_model import sanitize_doc
+
+from bluesky_kafka import BlueskyKafkaException
+from bluesky_kafka.tools.queue_thread import (
+    build_and_start_kafka_publisher_thread,
+    start_kafka_publisher_thread,
+)
+
+
+def test_build_and_start_kafka_publisher_thread(
+    kafka_bootstrap_servers,
+    temporary_topics,
+    consume_documents_from_kafka_until_first_stop_document,
+    RE,
+    hw,
+):
+    """Test publishing Kafka messages from a thread.
+
+    This test follows the pattern in bluesky_kafka/tests/test_in_single_process.py,
+    which is to publish Kafka messages _before_ subscribing a Kafka consumer to
+    those messages. After the messages have been published a consumer is subscribed
+    to the topic and should receive all messages since they will have been cached by
+    the Kafka broker(s). This keeps the test code relatively simple.
+
+    Parameters
+    ----------
+    kafka_bootstrap_servers: str (pytest fixture)
+        comma-delimited string of Kafka broker host:port, for example "kafka1:9092,kafka2:9092"
+    temporary_topics: context manager (pytest fixture)
+        creates and cleans up temporary Kafka topics for testing
+    consume_documents_from_kafka_until_first_stop_document: pytest fixture
+        a pytest fixture that runs a Kafka consumer until the first Kafka message
+        containing a stop document is encountered
+    RE: pytest fixture
+        bluesky RunEngine
+    hw: pytest fixture
+        ophyd simulated hardware objects
+    """
+
+    # use a random string as the beamline name so topics will not be duplicated across tests
+    beamline_name = str(uuid.uuid4())[:8]
+    with temporary_topics(topics=[f"{beamline_name}.bluesky.runengine.documents"]) as (
+        beamline_topic,
+    ):
+        (
+            kafka_publisher_queue,
+            kafka_publisher_thread_exit_event,
+        ) = build_and_start_kafka_publisher_thread(
+            topic=beamline_topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config={},
+            #     "acks": "all",
+            #     "enable.idempotence": False,
+            #     "request.timeout.ms": 1000,
+            # },
+        )
+
+        assert isinstance(kafka_publisher_queue, queue.Queue)
+        assert isinstance(kafka_publisher_thread_exit_event, threading.Event)
+
+        published_bluesky_documents = []
+
+        # store all documents published directly by the RunEngine
+        # for comparison with documents published by Kafka
+        def store_published_document(name, document):
+            published_bluesky_documents.append((name, document))
+
+        RE.subscribe(store_published_document)
+
+        # put each document published by the RunEngine
+        # on the kafka_publisher_queue
+        def put_document_on_publisher_queue(name, doc):
+            kafka_publisher_queue.put((name, doc))
+
+        RE.subscribe(put_document_on_publisher_queue)
+
+        # all documents created by this plan are expected
+        # to be published as Kafka messages
+        RE(count([hw.det]))
+
+        # it is known that RE(count()) will produce four
+        # documents: start, descriptor, event, stop
+        assert len(published_bluesky_documents) == 4
+
+        # retrieve the documents published as Kafka messages
+        consumed_bluesky_documents = consume_documents_from_kafka_until_first_stop_document(
+            kafka_topic=beamline_topic
+        )
+
+        assert len(published_bluesky_documents) == len(consumed_bluesky_documents)
+
+        # sanitize_doc normalizes some document data, such as numpy arrays, that are
+        # problematic for direct comparison of documents by 'assert'
+        sanitized_published_bluesky_documents = [
+            sanitize_doc(doc) for doc in published_bluesky_documents
+        ]
+        sanitized_consumed_bluesky_documents = [
+            sanitize_doc(doc) for doc in consumed_bluesky_documents
+        ]
+
+        assert len(sanitized_consumed_bluesky_documents) == len(
+            sanitized_published_bluesky_documents
+        )
+        assert (
+            sanitized_consumed_bluesky_documents
+            == sanitized_published_bluesky_documents
+        )
+
+
+def test_no_beamline_topic(caplog, kafka_bootstrap_servers, RE):
+    """ Test the case of a topic that does not exist in the Kafka broker.
+
+    If the beamline Kafka topic does not exist then an exception
+    should be raised and handled by writing an exception message
+    to the bluesky_kafka logger.
+
+    Parameters
+    ----------
+    caplog: built-in pytest fixture
+        logging output will be captured by this fixture
+    kafka_bootstrap_servers: str (pytest fixture)
+        comma-delimited string of Kafka broker host:port, for example "kafka1:9092,kafka2:9092"
+    RE: RunEngine (pytest fixture)
+        bluesky RunEngine
+    """
+
+    with caplog.at_level(level=logging.ERROR, logger="bluesky_kafka"):
+        # use a random string as the beamline name so topics will not be duplicated across tests
+        beamline_name = str(uuid.uuid4())[:8]
+        beamline_topic = f"{beamline_name}.bluesky.runengine.documents"
+        build_and_start_kafka_publisher_thread(
+            topic=beamline_topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config={},
+            #     "acks": "all",
+            #     "enable.idempotence": False,
+            #     "request.timeout.ms": 1000,
+            # },
+        )
+
+        assert (
+            f"topic `{beamline_topic}` does not exist on Kafka broker(s)" in caplog.text
+        )
+
+
+def test_subscribe_kafka_publisher(caplog, temporary_topics, RE):
+    """Test exception handling when a bluesky_kafka.Publisher raises an exception.
+
+    Parameters
+    ----------
+    caplog: built-in pytest fixture
+        logging output will be captured by this fixture
+    temporary_topics: context manager (pytest fixture)
+        creates and cleans up temporary Kafka topics for testing
+    RE: pytest fixture
+        bluesky RunEngine
+
+    """
+
+    # use a random string as the beamline name so topics will not be duplicated across tests
+    beamline_name = str(uuid.uuid4())[:8]
+    with temporary_topics(topics=[f"{beamline_name}.bluesky.runengine.documents"]) as (
+        beamline_topic,
+    ), caplog.at_level(logging.ERROR, logger="bluesky_kafka"):
+
+        publisher_queue = queue.Queue()
+        mock_kafka_publisher = Mock(side_effect=BlueskyKafkaException())
+        (
+            kafka_publisher_queue,
+            kafka_publisher_thread,
+            kafka_publisher_thread_stop_event,
+        ) = start_kafka_publisher_thread(
+            publisher_queue=publisher_queue,
+            publisher=mock_kafka_publisher,
+            publisher_queue_timeout=1,
+        )
+
+        # provoke two exceptions
+        publisher_queue.put(("start", {}))
+        publisher_queue.put(("stop", {}))
+
+        # wait until both documents have been removed from the queue
+        while not publisher_queue.empty():
+            print("waiting for queue to empty")
+            ttime.sleep(1)
+
+        # stop the polling loop
+        kafka_publisher_thread_stop_event.set()
+        kafka_publisher_thread.join()
+
+        # the logging output should contain 2 ERROR log records
+        # with thread name starting with "kafka-publisher-thread-",
+        # one for the start document, one for the stop document
+        kafka_publisher_thread_log_records = [
+            log_record
+            for log_record
+            in caplog.records
+            if log_record.threadName.startswith("kafka-publisher-thread-")
+        ]
+        assert len(kafka_publisher_thread_log_records) == 2
+
+        expected_log_message_pattern = re.compile(
+            r"an error occurred after 0 successful Kafka messages when "
+            r"'<Mock id='\d+'>' attempted to publish on topic <Mock name='mock.topic' id='\d+'>"
+        )
+
+        # test some aspects of each log record
+        for error_log_record, expected_document_name in zip(
+            kafka_publisher_thread_log_records, ("start", "stop")
+        ):
+            error_log_message = error_log_record.getMessage()
+            assert expected_log_message_pattern.search(error_log_message)
+            assert f"name: '{expected_document_name}'" in error_log_message
+
+
+def test_publisher_with_no_broker(RE, hw):
+    """Test the case of no Kafka broker.
+
+    In this case build_and_start_kafka_publisher_thread
+    should not raise an exception, but the returned
+    publisher queue should be None.
+    """
+
+    beamline_name = str(uuid.uuid4())[:8]
+    (
+        kafka_publisher_queue,
+        kafka_publisher_thread_exit_event,
+    ) = build_and_start_kafka_publisher_thread(
+        topic=beamline_name,
+        # specify a bootstrap server that does not exist
+        bootstrap_servers="100.100.100.100:9092",
+        producer_config={},
+        #     "acks": "all",
+        #     "enable.idempotence": False,
+        #     "request.timeout.ms": 1000,
+        # },
+        publisher_queue_timeout=1,
+    )
+
+    # in the case of no Kafka broker the publisher queue is None
+    assert kafka_publisher_queue is None
+
+    published_bluesky_documents = []
+
+    # store all documents published directly by the RunEngine
+    # to verify the expected documents were generated
+    def store_published_document(name, document):
+        published_bluesky_documents.append((name, document))
+
+    RE.subscribe(store_published_document)
+
+    RE(count([hw.det1]))
+
+    # the RunEngine should have published 4 documents
+    assert len(published_bluesky_documents) == 4

--- a/bluesky_kafka/tests/test_utils.py
+++ b/bluesky_kafka/tests/test_utils.py
@@ -5,7 +5,12 @@ import pytest
 from confluent_kafka.cimpl import KafkaException
 
 from bluesky_kafka import BlueskyKafkaException
-from bluesky_kafka.utils import get_cluster_metadata, create_topics, delete_topics, list_topics
+from bluesky_kafka.utils import (
+    get_cluster_metadata,
+    create_topics,
+    delete_topics,
+    list_topics,
+)
 
 
 def test_get_cluster_metadata_no_broker():
@@ -16,9 +21,7 @@ def test_get_cluster_metadata_no_broker():
     which means it will hang forever if no connection can be made to a broker.
     """
     with pytest.raises(KafkaException):
-        get_cluster_metadata(
-            bootstrap_servers="1.1.1.1:9092"
-        )
+        get_cluster_metadata(bootstrap_servers="1.1.1.1:9092")
 
 
 def test_list_topics_no_broker():
@@ -29,9 +32,7 @@ def test_list_topics_no_broker():
     which means it will hang forever if no connection can be made to a broker.
     """
     with pytest.raises(KafkaException):
-        list_topics(
-            bootstrap_servers="1.1.1.1:9092"
-        )
+        list_topics(bootstrap_servers="1.1.1.1:9092")
 
 
 def test_create_topics(kafka_bootstrap_servers):
@@ -88,8 +89,7 @@ def test_create_topics_name_failure(kafka_bootstrap_servers):
             match=re.escape("failed to create topic(s) ['topic.a!']"),
         ):
             create_topics(
-                bootstrap_servers=kafka_bootstrap_servers,
-                topics_to_create=new_topics,
+                bootstrap_servers=kafka_bootstrap_servers, topics_to_create=new_topics,
             )
 
         all_topics = set(list_topics(bootstrap_servers=kafka_bootstrap_servers).keys())

--- a/bluesky_kafka/tools/queue_thread.py
+++ b/bluesky_kafka/tools/queue_thread.py
@@ -1,0 +1,213 @@
+import logging
+import threading
+import queue
+import uuid
+
+from bluesky_kafka import BlueskyKafkaException, Publisher
+from bluesky_kafka.utils import list_topics
+
+
+def start_kafka_publisher_thread(
+    publisher, publisher_queue=None, publisher_queue_timeout=1
+):
+    """Start a thread to take (name, document) tuples off a Queue and publish them as Kafka messages.
+
+    Parameters
+    ----------
+    publisher: bluesky_kafka.Publisher
+        publishes (name, document) tuples as Kafka messages
+    publisher_queue: queue.Queue-like object (optional)
+        (name, document) tuples placed on this queue will be published as Kafka messages
+        by the specified publisher; by default a queue.Queue will be used
+    publisher_queue_timeout: float
+        time in seconds to wait for a document to become available on the publisher_queue
+        before checking if the publisher thread should terminate; default is 1s
+
+    Returns
+    -------
+    publisher_queue
+        (name, document) tuples placed on this queue.Queue-like object will be published
+        as Kafka messages by the specified publisher
+    publisher_thread
+        threading.Thread responsible for running function publish_documents_from_publisher_queue
+    publisher_thread_stop_event
+        call set() on this threading.Event to terminate publisher_thread
+
+    """
+
+    def publish_documents_from_publisher_queue(
+        publisher_,
+        publisher_queue_,
+        publisher_thread_stop_event_,
+        publisher_queue_timeout_=1,
+    ):
+        """
+        This function is intended to execute in a dedicated thread. It defines a polling
+        loop that takes (name, document) tuples from publisher_queue_ as they become
+        available and uses publisher_ to publish those tuples as Kafka messages.
+
+        The intention is to separate a RunEngine or other source of documents
+        from a Publisher in order to insulate plans from Publisher failures that
+        might otherwise interrupt data collection.
+
+        Parameters
+        ---------
+        publisher_:  bluesky_kafka.Publisher
+            publishes (name, document) tuples as Kafka messages on a beamline-specific topic
+        publisher_queue_: queue.Queue-like object
+            (name, document) tuples placed on this queue will be published as
+            Kafka messages by the publisher_
+        publisher_thread_stop_event_: threading.Event
+            the polling loop will terminate cleanly if publisher_thread_stop_event_ is set
+        publisher_queue_timeout_: float
+            time in seconds to wait for a document to become available on publisher_queue_
+            before checking if publisher_thread_stop_event_ has been set
+        """
+        name_ = None
+        document_ = None
+        published_document_count = 0
+        logger_ = logging.getLogger("bluesky_kafka")
+        logger_.info("starting Kafka message publishing loop")
+        while not publisher_thread_stop_event_.is_set():
+            try:
+                name_, document_ = publisher_queue_.get(
+                    timeout=publisher_queue_timeout_
+                )
+                publisher_(name_, document_)
+                published_document_count += 1
+            except queue.Empty:
+                # publisher_queue_.get() timed out waiting for a new document
+                # the while condition will now be checked to see if someone
+                # has requested that this thread terminate
+                # if not then try again to get a new document from publisher_queue_
+                pass
+            except BaseException:
+                # something bad happened while trying to publish a Kafka message
+                # log the exception and continue taking documents from publisher_queue_
+                logger_.exception(
+                    "an error occurred after %d successful Kafka messages when '%s' "
+                    "attempted to publish on topic %s\nname: '%s'\ndoc '%s'",
+                    published_document_count,
+                    publisher_,
+                    publisher_.topic,
+                    name_,
+                    document_,
+                )
+
+    if publisher_queue is None:
+        publisher_queue = queue.Queue()
+    publisher_thread_stop_event = threading.Event()
+    publisher_thread = threading.Thread(
+        # include a random string in the thread name in case
+        # more than one Kafka publisher thread is started
+        name=f"kafka-publisher-thread-{str(uuid.uuid4())[:8]}",
+        target=publish_documents_from_publisher_queue,
+        kwargs={
+            "publisher_": publisher,
+            "publisher_queue_": publisher_queue,
+            "publisher_thread_stop_event_": publisher_thread_stop_event,
+            "publisher_queue_timeout_": publisher_queue_timeout,
+        },
+        daemon=True,
+    )
+    publisher_thread.start()
+    logger = logging.getLogger("bluesky_kafka")
+    logger.info("Kafka publisher thread has started")
+    return publisher_queue, publisher_thread, publisher_thread_stop_event
+
+
+def build_and_start_kafka_publisher_thread(
+    topic,
+    bootstrap_servers,
+    producer_config,
+    publisher_queue=None,
+    publisher_queue_timeout=1,
+):
+    """
+    Create and start a separate thread to publish bluesky documents as Kafka
+    messages.
+
+    This function performs four tasks:
+      1) verify a Kafka broker with the expected beamline-specific topic is available
+      2) instantiate a bluesky_kafka.Publisher with the specified topic and configuration
+      3) call start_kafka_publisher_thread to start a polling loop to publish (name, document)
+         tuples placed on the publisher queue
+      4) return the publisher queue so client code can put (name, document) tuples on it
+
+    Parameters
+    ----------
+    topic: str
+        topic for Kafka messages
+    bootstrap_servers: str
+        Comma-delimited list of Kafka server addresses or hostnames and ports as a string
+        such as ``'kafka1:9092,kafka2:9092``
+    producer_config: dict
+        dictionary of Kafka Producer configuration settings
+    publisher_queue: queue.Queue-like object (optional)
+        (name, document) tuples placed on this queue will be published as Kafka messages
+        by kafka_publisher; by default a queue.Queue will be used
+    publisher_queue_timeout: float (optional)
+        time in seconds to wait for a document to become available on the publisher_queue
+        before checking if the publisher thread should terminate; default is 1s
+
+    Returns
+    -------
+    publisher_queue: queue.Queue-like object
+        (name, document) tuples placed on this queue will be published as Kafka messages
+        by kafka_publisher. If no Kafka broker can be found the returned publisher_queue
+        will be None.
+    publisher_thread_stop_event: threading.Event
+        call set() on this threading.Event to terminate the message publication loop;
+        this may have unexpected memory consequences if (name, document) tuples continue
+        to be placed on publisher_queue
+    """
+
+    logger = logging.getLogger("bluesky_kafka")
+
+    # let's not confuse the publisher_queue parameter, which is None by default,
+    # with the queue that will be returned, which is None only in a failure mode
+    final_publisher_queue = None
+    publisher_thread_stop_event = None
+
+    try:
+        logger.info("connecting to Kafka broker(s): '%s'", bootstrap_servers)
+        # verify the specified topic exists on the Kafka broker(s) before subscribing
+        topic_to_topic_metadata = list_topics(bootstrap_servers=bootstrap_servers)
+        if topic in topic_to_topic_metadata:
+            # since the topic exists, build a Publisher for the topic
+            kafka_publisher = Publisher(
+                topic=topic,
+                bootstrap_servers=bootstrap_servers,
+                # specify a key to guarantee messages will be delivered in order
+                key=str(uuid.uuid4()),
+                producer_config=producer_config,
+                flush_on_stop_doc=True,
+            )
+            (
+                final_publisher_queue,
+                publisher_thread,
+                publisher_thread_stop_event,
+            ) = start_kafka_publisher_thread(
+                publisher_queue=publisher_queue,
+                publisher=kafka_publisher,
+                publisher_queue_timeout=publisher_queue_timeout,
+            )
+            logger.info(
+                "RunEngine will publish bluesky documents on Kafka topic '%s'",
+                topic,
+            )
+        else:
+            raise BlueskyKafkaException(
+                f"topic `{topic}` does not exist on Kafka broker(s) `{bootstrap_servers}`",
+            )
+    except BaseException:
+        """
+        An exception at this point means Kafka
+        messages will not be published.
+        """
+        logger.exception(
+            "Kafka messages can not be published on topic '%s'",
+            topic,
+        )
+
+    return final_publisher_queue, publisher_thread_stop_event

--- a/bluesky_kafka/tools/queue_thread.py
+++ b/bluesky_kafka/tools/queue_thread.py
@@ -3,14 +3,35 @@ import threading
 import queue
 import uuid
 
+from collections import namedtuple
+
 from bluesky_kafka import BlueskyKafkaException, Publisher
 from bluesky_kafka.utils import list_topics
 
 
-def start_kafka_publisher_thread(
+"""
+A namedtuple for holding details of a publisher queue and thread
+constructed by build_publisher_queue_and_thread(...).
+
+This namedtuple is not intended to be created by client code.
+"""
+_PublisherQueueThreadDetails = namedtuple(
+    "PublisherQueueThreadDetails",
+    [
+        "publisher_queue",
+        "publisher_thread",
+        "publisher_thread_stop_event",
+        "put_on_publisher_queue",
+    ],
+)
+
+
+def _start_kafka_publisher_thread(
     publisher, publisher_queue=None, publisher_queue_timeout=1
 ):
     """Start a thread to take (name, document) tuples off a Queue and publish them as Kafka messages.
+
+    This function is intended for internal use and testing, not for use in client code.
 
     Parameters
     ----------
@@ -52,7 +73,7 @@ def start_kafka_publisher_thread(
 
         Parameters
         ---------
-        publisher_:  bluesky_kafka.Publisher
+        publisher_: bluesky_kafka.Publisher
             publishes (name, document) tuples as Kafka messages on a beamline-specific topic
         publisher_queue_: queue.Queue-like object
             (name, document) tuples placed on this queue will be published as
@@ -113,26 +134,35 @@ def start_kafka_publisher_thread(
     publisher_thread.start()
     logger = logging.getLogger("bluesky_kafka")
     logger.info("Kafka publisher thread has started")
-    return publisher_queue, publisher_thread, publisher_thread_stop_event
+
+    publisher_queue_thread_details = _PublisherQueueThreadDetails(
+        publisher_queue=publisher_queue,
+        publisher_thread=publisher_thread,
+        publisher_thread_stop_event=publisher_thread_stop_event,
+        put_on_publisher_queue=lambda name, document: publisher_queue.put(
+            (name, document)
+        ),
+    )
+
+    return publisher_queue_thread_details
 
 
-def build_and_start_kafka_publisher_thread(
+def build_kafka_publisher_queue_and_thread(
     topic,
     bootstrap_servers,
     producer_config,
     publisher_queue=None,
     publisher_queue_timeout=1,
 ):
-    """
-    Create and start a separate thread to publish bluesky documents as Kafka
-    messages.
+    """Create and start a separate thread to publish bluesky documents as Kafka messages.
 
     This function performs four tasks:
-      1) verify a Kafka broker with the expected beamline-specific topic is available
+      1) verify a Kafka broker with the specified topic is available
       2) instantiate a bluesky_kafka.Publisher with the specified topic and configuration
-      3) call start_kafka_publisher_thread to start a polling loop to publish (name, document)
+      3) if publisher_queue=None is specified instantiate a queue.Queue
+      4) call _start_kafka_publisher_thread to start a polling loop to publish (name, document)
          tuples placed on the publisher queue
-      4) return the publisher queue so client code can put (name, document) tuples on it
+      5) return the publisher queue so client code can put (name, document) tuples on it
 
     Parameters
     ----------
@@ -152,62 +182,56 @@ def build_and_start_kafka_publisher_thread(
 
     Returns
     -------
-    publisher_queue: queue.Queue-like object
-        (name, document) tuples placed on this queue will be published as Kafka messages
-        by kafka_publisher. If no Kafka broker can be found the returned publisher_queue
-        will be None.
-    publisher_thread_stop_event: threading.Event
-        call set() on this threading.Event to terminate the message publication loop;
-        this may have unexpected memory consequences if (name, document) tuples continue
-        to be placed on publisher_queue
+    PublisherQueueThreadDetails: namedtuple with these attributes:
+        publisher_queue: queue.Queue-like object
+            (name, document) tuples placed on this queue will be published as Kafka messages
+            by kafka_publisher. If no Kafka broker can be found the returned publisher_queue
+            will be None.
+        publisher_thread: threading.Thread
+            the thread that publishes (name, document) tuples placed on the publisher_queue
+            as Kafka messages
+        publisher_thread_stop_event: threading.Event
+            call set() on this threading.Event to terminate the message publication loop;
+            this may have unexpected memory consequences if (name, document) tuples continue
+            to be placed on publisher_queue
+        put_on_thread_queue: function(name, document) -> None
+            a convenience function to put name, document pairs on the publisher_queue, suitable for
+            RunEngine subscription: RE.subscribe(put_on_thread_queue)
     """
 
     logger = logging.getLogger("bluesky_kafka")
 
-    # let's not confuse the publisher_queue parameter, which is None by default,
-    # with the queue that will be returned, which is None only in a failure mode
-    final_publisher_queue = None
-    publisher_thread_stop_event = None
-
-    try:
-        logger.info("connecting to Kafka broker(s): '%s'", bootstrap_servers)
-        # verify the specified topic exists on the Kafka broker(s) before subscribing
-        topic_to_topic_metadata = list_topics(bootstrap_servers=bootstrap_servers)
-        if topic in topic_to_topic_metadata:
-            # since the topic exists, build a Publisher for the topic
-            kafka_publisher = Publisher(
-                topic=topic,
-                bootstrap_servers=bootstrap_servers,
-                # specify a key to guarantee messages will be delivered in order
-                key=str(uuid.uuid4()),
-                producer_config=producer_config,
-                flush_on_stop_doc=True,
-            )
-            (
-                final_publisher_queue,
-                publisher_thread,
-                publisher_thread_stop_event,
-            ) = start_kafka_publisher_thread(
-                publisher_queue=publisher_queue,
-                publisher=kafka_publisher,
-                publisher_queue_timeout=publisher_queue_timeout,
-            )
-            logger.info(
-                "RunEngine will publish bluesky documents on Kafka topic '%s'",
-                topic,
-            )
-        else:
-            raise BlueskyKafkaException(
-                f"topic `{topic}` does not exist on Kafka broker(s) `{bootstrap_servers}`",
-            )
-    except BaseException:
-        """
-        An exception at this point means Kafka
-        messages will not be published.
-        """
-        logger.exception(
-            "Kafka messages can not be published on topic '%s'",
+    logger.info("connecting to Kafka broker(s): '%s'", bootstrap_servers)
+    # verify the specified topic exists on the Kafka broker(s) before subscribing
+    topic_to_topic_metadata = list_topics(bootstrap_servers=bootstrap_servers)
+    if topic in topic_to_topic_metadata:
+        # since the topic exists, build a Publisher for the topic
+        kafka_publisher = Publisher(
+            topic=topic,
+            bootstrap_servers=bootstrap_servers,
+            # specify a key to guarantee messages will be delivered in order
+            key=str(uuid.uuid4()),
+            producer_config=producer_config,
+            flush_on_stop_doc=True,
+        )
+        publisher_queue_thread_details = _start_kafka_publisher_thread(
+            publisher_queue=publisher_queue,
+            publisher=kafka_publisher,
+            publisher_queue_timeout=publisher_queue_timeout,
+        )
+        logger.info(
+            "bluesky documents placed on queue `%s` will be published on Kafka topic '%s'",
+            publisher_queue_thread_details.publisher_queue,
             topic,
         )
+    else:
+        logger.error(
+            f"topic `%s` does not exist on Kafka broker(s) `%s`",
+            topic,
+            bootstrap_servers,
+        )
+        raise BlueskyKafkaException(
+            f"topic `{topic}` does not exist on Kafka broker(s) `{bootstrap_servers}`",
+        )
 
-    return final_publisher_queue, publisher_thread_stop_event
+    return publisher_queue_thread_details

--- a/scripts/start_kafka.sh
+++ b/scripts/start_kafka.sh
@@ -1,0 +1,1 @@
+sudo docker-compose -f bitnami-kafka-docker-compose.yml up


### PR DESCRIPTION
Functions were developed in the nslsii project for publishing messages from a (separate) thread with robust exception handling. Over time it became clear that these functions would be useful outside of the nslsii package, in particular for beamlines that were not yet running the latest version of nslsii. This PR adapts those functions for general use by removing the dependence on a RunEngine.

A future PR to nslsii will remove the original code and replace it with the coded added here.

draft release note:
 - add new functions for publishing messages from a separate thread in bluesky_kafka.tools.queue_thread