### PR TITLE
Add function and method parameters to specify Kafka connection options

### DIFF
--- a/bluesky_kafka/tests/test_in_single_process.py
+++ b/bluesky_kafka/tests/test_in_single_process.py
@@ -104,8 +104,10 @@ def test_publisher_and_consumer(
         assert len(published_bluesky_documents) == 4
 
         # retrieve the documents published as Kafka messages
-        consumed_bluesky_documents = consume_documents_from_kafka_until_first_stop_document(
-            kafka_topic=topic, deserializer=deserializer
+        consumed_bluesky_documents = (
+            consume_documents_from_kafka_until_first_stop_document(
+                kafka_topic=topic, deserializer=deserializer
+            )
         )
 
         assert len(published_bluesky_documents) == len(consumed_bluesky_documents)
@@ -134,6 +136,7 @@ def test_publisher_and_consumer(
 )
 def test_publisher_and_remote_dispatcher(
     kafka_bootstrap_servers,
+    test_broker_authorization_config,
     temporary_topics,
     publisher_factory,
     hw,
@@ -148,6 +151,8 @@ def test_publisher_and_remote_dispatcher(
     ----------
     kafka_bootstrap_servers: str (pytest fixture)
         comma-delimited string of Kafka broker host:port, for example "localhost:9092"
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     temporary_topics: context manager (pytest fixture)
         creates and cleans up temporary Kafka topics for testing
     publisher_factory: pytest fixture
@@ -196,16 +201,19 @@ def test_publisher_and_remote_dispatcher(
         # documents: start, descriptor, event, stop
         assert len(published_bluesky_documents) == 4
 
+        consumer_config = {
+            # this consumer is intended to read messages that
+            # have already been published, so it is necessary
+            # to specify "earliest" here
+            "auto.offset.reset": "earliest",
+        }
+        consumer_config.update(test_broker_authorization_config)
+
         remote_dispatcher = RemoteDispatcher(
             topics=[topic],
             bootstrap_servers=kafka_bootstrap_servers,
             group_id=f"{topic}.consumer.group",
-            consumer_config={
-                # this consumer is intended to read messages that
-                # have already been published, so it is necessary
-                # to specify "earliest" here
-                "auto.offset.reset": "earliest",
-            },
+            consumer_config=consumer_config,
             polling_duration=1.0,
             deserializer=deserializer,
         )
@@ -228,7 +236,9 @@ def test_publisher_and_remote_dispatcher(
                 return True
 
         # start() will return when 'until_first_stop_document' returns False
-        remote_dispatcher.start(continue_polling=until_first_stop_document,)
+        remote_dispatcher.start(
+            continue_polling=until_first_stop_document,
+        )
 
         assert len(published_bluesky_documents) == len(dispatched_bluesky_documents)
 

--- a/bluesky_kafka/tests/test_queue_thread.py
+++ b/bluesky_kafka/tests/test_queue_thread.py
@@ -24,6 +24,7 @@ from bluesky_kafka.tools.queue_thread import (
 
 def test_build_kafka_publisher_queue_and_thread(
     kafka_bootstrap_servers,
+    test_broker_authorization_config,
     temporary_topics,
     consume_documents_from_kafka_until_first_stop_document,
     RE,
@@ -41,6 +42,8 @@ def test_build_kafka_publisher_queue_and_thread(
     ----------
     kafka_bootstrap_servers: str (pytest fixture)
         comma-delimited string of Kafka broker host:port, for example "kafka1:9092,kafka2:9092"
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     temporary_topics: context manager (pytest fixture)
         creates and cleans up temporary Kafka topics for testing
     consume_documents_from_kafka_until_first_stop_document: pytest fixture
@@ -60,7 +63,7 @@ def test_build_kafka_publisher_queue_and_thread(
         publisher_queue_thread_details = build_kafka_publisher_queue_and_thread(
             topic=beamline_topic,
             bootstrap_servers=kafka_bootstrap_servers,
-            producer_config={},
+            producer_config=test_broker_authorization_config,
         )
 
         assert isinstance(publisher_queue_thread_details.publisher_queue, queue.Queue)
@@ -68,7 +71,8 @@ def test_build_kafka_publisher_queue_and_thread(
             publisher_queue_thread_details.publisher_thread, threading.Thread
         )
         assert isinstance(
-            publisher_queue_thread_details.publisher_thread_stop_event, threading.Event,
+            publisher_queue_thread_details.publisher_thread_stop_event,
+            threading.Event,
         )
         assert isinstance(
             publisher_queue_thread_details.put_on_publisher_queue, Callable
@@ -94,8 +98,10 @@ def test_build_kafka_publisher_queue_and_thread(
         assert len(published_bluesky_documents) == 4
 
         # retrieve the documents published as Kafka messages
-        consumed_bluesky_documents = consume_documents_from_kafka_until_first_stop_document(
-            kafka_topic=beamline_topic
+        consumed_bluesky_documents = (
+            consume_documents_from_kafka_until_first_stop_document(
+                kafka_topic=beamline_topic
+            )
         )
 
         assert len(published_bluesky_documents) == len(consumed_bluesky_documents)
@@ -118,8 +124,10 @@ def test_build_kafka_publisher_queue_and_thread(
         )
 
 
-def test_no_topic(caplog, kafka_bootstrap_servers, RE):
-    """ Test the case of a topic that does not exist in the Kafka broker.
+def test_no_topic(
+    caplog, kafka_bootstrap_servers, test_broker_authorization_config, RE
+):
+    """Test the case of a topic that does not exist in the Kafka broker.
 
     If the topic does not exist a BlueskyKafkaException
     should be raised. In addition an ERROR should be logged.
@@ -130,6 +138,8 @@ def test_no_topic(caplog, kafka_bootstrap_servers, RE):
         logging output will be captured by this fixture
     kafka_bootstrap_servers: str (pytest fixture)
         comma-delimited string of Kafka broker host:port, for example "kafka1:9092,kafka2:9092"
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     RE: RunEngine (pytest fixture)
         bluesky RunEngine
     """
@@ -142,7 +152,7 @@ def test_no_topic(caplog, kafka_bootstrap_servers, RE):
         build_kafka_publisher_queue_and_thread(
             topic=topic,
             bootstrap_servers=kafka_bootstrap_servers,
-            producer_config={},
+            producer_config=test_broker_authorization_config,
         )
 
     assert f"topic `{topic}` does not exist on Kafka broker(s)" in caplog.text
@@ -164,9 +174,9 @@ def test__subscribe_kafka_publisher(caplog, temporary_topics, RE):
     """
 
     # use a random string so topics will not be duplicated across tests
-    with temporary_topics(topics=[str(uuid.uuid4())[:8]]) as (
-        topic,
-    ), caplog.at_level(logging.ERROR, logger="bluesky_kafka"):
+    with temporary_topics(topics=[str(uuid.uuid4())[:8]]) as (topic,), caplog.at_level(
+        logging.ERROR, logger="bluesky_kafka"
+    ):
 
         publisher_queue = queue.Queue()
         mock_kafka_publisher = Mock(side_effect=BlueskyKafkaException())

--- a/bluesky_kafka/tests/test_utils.py
+++ b/bluesky_kafka/tests/test_utils.py
@@ -13,29 +13,44 @@ from bluesky_kafka.utils import (
 )
 
 
-def test_get_cluster_metadata_no_broker():
+def test_get_cluster_metadata_no_broker(test_broker_authorization_config):
     """
-    Test the default 10s timeout for get_cluster_metadata().
+    Test the default 10s timeout for bluesky_kafka.utils.get_cluster_metadata().
 
     The default behavior for confluent_kakfa.Producer.list_topics() is no timeout,
     which means it will hang forever if no connection can be made to a broker.
+
+    Parameters
+    ----------
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     """
     with pytest.raises(KafkaException):
-        get_cluster_metadata(bootstrap_servers="1.1.1.1:9092")
+        get_cluster_metadata(
+            bootstrap_servers="1.1.1.1:9092",
+            producer_config=test_broker_authorization_config,
+        )
 
 
-def test_list_topics_no_broker():
+def test_list_topics_no_broker(test_broker_authorization_config):
     """
-    Test the default 10s timeout for list_topics().
+    Test the default 10s timeout for bluesky_kafka.utils.list_topics().
 
     The default behavior for confluent_kakfa.Producer.list_topics() is no timeout,
     which means it will hang forever if no connection can be made to a broker.
+    Parameters
+    ----------
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     """
     with pytest.raises(KafkaException):
-        list_topics(bootstrap_servers="1.1.1.1:9092")
+        list_topics(
+            bootstrap_servers="1.1.1.1:9092",
+            producer_config=test_broker_authorization_config,
+        )
 
 
-def test_create_topics(kafka_bootstrap_servers):
+def test_create_topics(kafka_bootstrap_servers, test_broker_authorization_config):
     """
     Test creation and verification of new topics.
 
@@ -46,28 +61,38 @@ def test_create_topics(kafka_bootstrap_servers):
     ----------
     kafka_bootstrap_servers: str (pytest fixture)
         comma-delimited string of hostname:port, for example "localhost:9092"
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     """
 
     new_topics = {"topic.a", "topic.b", "topic.c"}
     delete_topics(
-        bootstrap_servers=kafka_bootstrap_servers, topics_to_delete=new_topics
+        bootstrap_servers=kafka_bootstrap_servers,
+        topics_to_delete=new_topics,
+        admin_client_config=test_broker_authorization_config,
     )
 
     try:
         create_topics(
-            bootstrap_servers=kafka_bootstrap_servers, topics_to_create=new_topics
+            bootstrap_servers=kafka_bootstrap_servers,
+            topics_to_create=new_topics,
+            admin_client_config=test_broker_authorization_config,
         )
         all_topics = set(list_topics(bootstrap_servers=kafka_bootstrap_servers).keys())
     finally:
         # clean up the topics used for this test before asserting anything
         delete_topics(
-            bootstrap_servers=kafka_bootstrap_servers, topics_to_delete=new_topics
+            bootstrap_servers=kafka_bootstrap_servers,
+            topics_to_delete=new_topics,
+            admin_client_config=test_broker_authorization_config,
         )
 
     assert new_topics & all_topics == new_topics
 
 
-def test_create_topics_name_failure(kafka_bootstrap_servers):
+def test_create_topics_name_failure(
+    kafka_bootstrap_servers, test_broker_authorization_config
+):
     """
     Force a failure with an illegal topic name. Topics with
     valid names will be created.
@@ -76,11 +101,15 @@ def test_create_topics_name_failure(kafka_bootstrap_servers):
     ----------
     kafka_bootstrap_servers: str (pytest fixture)
         comma-delimited string of hostname:port, for example "localhost:9092"
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     """
 
     new_topics = {"topic.a!", "topic.b", "topic.c"}
     delete_topics(
-        bootstrap_servers=kafka_bootstrap_servers, topics_to_delete=new_topics
+        bootstrap_servers=kafka_bootstrap_servers,
+        topics_to_delete=new_topics,
+        admin_client_config=test_broker_authorization_config,
     )
 
     try:
@@ -89,20 +118,31 @@ def test_create_topics_name_failure(kafka_bootstrap_servers):
             match=re.escape("failed to create topic(s) ['topic.a!']"),
         ):
             create_topics(
-                bootstrap_servers=kafka_bootstrap_servers, topics_to_create=new_topics,
+                bootstrap_servers=kafka_bootstrap_servers,
+                topics_to_create=new_topics,
+                admin_client_config=test_broker_authorization_config,
             )
 
-        all_topics = set(list_topics(bootstrap_servers=kafka_bootstrap_servers).keys())
+        all_topics = set(
+            list_topics(
+                bootstrap_servers=kafka_bootstrap_servers,
+                producer_config=test_broker_authorization_config,
+            ).keys()
+        )
     finally:
         delete_topics(
-            bootstrap_servers=kafka_bootstrap_servers, topics_to_delete=new_topics
+            bootstrap_servers=kafka_bootstrap_servers,
+            topics_to_delete=new_topics,
+            admin_client_config=test_broker_authorization_config,
         )
 
     # the topics with legal names will be created
     assert new_topics & all_topics == {"topic.b", "topic.c"}
 
 
-def test_delete_nonexisting_topic(kafka_bootstrap_servers):
+def test_delete_nonexisting_topic(
+    kafka_bootstrap_servers, test_broker_authorization_config
+):
     """
     Trying to delete a topic that does not exist causes no error.
 
@@ -110,8 +150,11 @@ def test_delete_nonexisting_topic(kafka_bootstrap_servers):
     ----------
     kafka_bootstrap_servers: str (pytest fixture)
         comma-delimited string of hostname:port, for example "localhost:9092"
+    test_broker_authorization_config: dict
+        Kafka broker authentication parameters for the test broker
     """
     delete_topics(
         bootstrap_servers=kafka_bootstrap_servers,
         topics_to_delete=["not.a.valid.topic!", "not.a.real.topic"],
+        admin_client_config=test_broker_authorization_config,
     )


### PR DESCRIPTION
Some functions and methods did not have parameters for specifying arbitrary Kafka configuration options. This was not a big problem until we started working with encryption and authorization. This PR adds function and method parameters to accept dictionaries with those configuration options, or any other Kafka configuration options.