### PR TITLE
Change BlueskyKafkaException base class to Exception

### DIFF
--- a/bluesky_kafka/__init__.py
+++ b/bluesky_kafka/__init__.py
@@ -20,7 +20,7 @@ mpn.patch()
 logger = logging.getLogger(name="bluesky.kafka")
 
 
-class BlueskyKafkaException(BaseException):
+class BlueskyKafkaException(Exception):
     pass
 
 


### PR DESCRIPTION
This PR changes the BlueskyKafkaException base class from BaseException to Exception.

The reason for this change is to give the BlueskyKafkaException more correct behavior as an exception raised by "user" code rather than "system" code. This change was prompted by unintended behavior of BlueskyKafkaException in python 3.7 code using asyncio.