### PR TITLE
Poll for delivery reports

### DIFF
--- a/bluesky_kafka/__init__.py
+++ b/bluesky_kafka/__init__.py
@@ -633,8 +633,18 @@ class MongoConsumer(BlueskyConsumer):
             )
             return result
 
-    def __init__(self, mongo_uri, topic_database_map, auth_source="admin", tls=False, *args, **kwargs):
-        self._serializers = self.SerializerFactory(mongo_uri, topic_database_map, auth_source, tls)
+    def __init__(
+        self,
+        mongo_uri,
+        topic_database_map,
+        auth_source="admin",
+        tls=False,
+        *args,
+        **kwargs,
+    ):
+        self._serializers = self.SerializerFactory(
+            mongo_uri, topic_database_map, auth_source, tls
+        )
         super().__init__(*args, **kwargs)
 
     def process_document(self, topic, name, doc):

--- a/bluesky_kafka/__init__.py
+++ b/bluesky_kafka/__init__.py
@@ -209,6 +209,8 @@ class Publisher:
             value=self._serializer((name, doc)),
             on_delivery=self.on_delivery,
         )
+        # poll for delivery reports
+        self._producer.poll(0)
         if self._flush_on_stop_doc and name == "stop":
             self.flush()
 

--- a/bluesky_kafka/tools/queue_thread.py
+++ b/bluesky_kafka/tools/queue_thread.py
@@ -203,7 +203,9 @@ def build_kafka_publisher_queue_and_thread(
 
     logger.info("connecting to Kafka broker(s): '%s'", bootstrap_servers)
     # verify the specified topic exists on the Kafka broker(s) before subscribing
-    topic_to_topic_metadata = list_topics(bootstrap_servers=bootstrap_servers, producer_config=producer_config)
+    topic_to_topic_metadata = list_topics(
+        bootstrap_servers=bootstrap_servers, producer_config=producer_config
+    )
     if topic in topic_to_topic_metadata:
         # since the topic exists, build a Publisher for the topic
         kafka_publisher = Publisher(


### PR DESCRIPTION
This PR modifies `Publisher.__call__` to invoke `Producer.poll(0)` after every message is published, which is a recommended practice. This may be important in cases where a large number of documents (for example, 100,000+ event documents) are published in a single run and the delivery reports fill the delivery report queue. This does not happen in shorter runs because the call to Producer.flush() that occurs after the stop document is published drains that queue.

This PR also adds assertions in `test_publisher_and_consumer` against the number of delivery reports.