### PR TITLE
Add missing comma

### DIFF
--- a/bluesky_kafka/mongo_normalized_consumer.py
+++ b/bluesky_kafka/mongo_normalized_consumer.py
@@ -58,7 +58,7 @@ topic_database_map = {'amx.bluesky.runengine.documents': 'amx-bluesky-documents'
 # new topics. The default value is 5000ms.
 mongo_consumer = MongoConsumer(
     mongo_uri,
-    topic_database_map
+    topic_database_map,
     tls=True,
     topics=topics,
     bootstrap_servers=bootstrap_servers,


### PR DESCRIPTION
Noticed this during [conda packaging](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=487168&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=249):
```py
Installing collected packages: bluesky-kafka
  *** Error compiling '$PREFIX/lib/python3.10/site-packages/bluesky_kafka/mongo_normalized_consumer.py'...
    File "$PREFIX/lib/python3.10/site-packages/bluesky_kafka/mongo_normalized_consumer.py", line 61
      topic_database_map
      ^^^
  SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

Fixes https://github.com/bluesky/bluesky-kafka/issues/45.