### PR TITLE
Tst: Enable  auto docker compose per test session

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/bluesky_kafka/tests/docker-compose.yml
+++ b/bluesky_kafka/tests/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+services:
+  zookeeper:
+    image: 'docker.io/bitnami/zookeeper:latest'
+    ports:
+      - '2181:2181'
+    volumes:
+      - 'zookeeper_data:/bitnami'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: 'docker.io/bitnami/kafka:latest'
+    ports:
+      - '9092:9092'
+      - '29092:29092'
+    volumes:
+      - 'kafka_data:/bitnami'
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:29092,PLAINTEXT_HOST://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
+    depends_on:
+      - zookeeper
+
+volumes:
+  zookeeper_data:
+    driver: local
+  kafka_data:
+    driver: local

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ numpydoc
 pyqt5
 sphinx-copybutton
 sphinx_rtd_theme
+pytest-docker


### PR DESCRIPTION
Was poking through the bluesky-kafka tests as I try and build tests for new features in bluesky-adaptive. Noticed the test suite was dependent on a docker image running kafka. 
Stumbled on this repo: https://github.com/avast/pytest-docker
Should simplify the conditional automated running of tests. 
Mostly want to test the appetite of the maintainers. It's great for just running the test suite automatically, it's a bit heavy for building out a single test (restarts the container at each run). Thoughts? 