### PR TITLE
CI: add a PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,39 @@
+# This workflow will upload a Python Package using flit when a release is
+# created.  For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: PyPI upload
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish_pypi:
+    name: Publish package to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel twine setuptools
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        # The PYPI_PASSWORD must be a pypi token with the "pypi-" prefix with sufficient permissions to upload this package
+        # https://pypi.org/help/#apitoken
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
Done in the same fashion as for other repos, but updated the tag for the `checkout` (`@v3`) and `setup-python` (`@v4`) actions.

## TODOs

- [x] Needs the `PYPI_API_TOKEN` secret configured for this repo.