### PR TITLE
De-dent unchecked assertions in pytest.raises blocks

### DIFF
--- a/bluesky_kafka/produce.py
+++ b/bluesky_kafka/produce.py
@@ -115,7 +115,6 @@ class BasicProducer:
             raise ValueError(
                 "do not specify 'bootstrap.servers' in producer_config dictionary, "
                 "use only the 'bootstrap_servers' parameter"
-                f"\n{self}"
             )
         else:
             self._producer_config["bootstrap.servers"] = ",".join(bootstrap_servers)

--- a/bluesky_kafka/tests/test_basic_consumer.py
+++ b/bluesky_kafka/tests/test_basic_consumer.py
@@ -42,10 +42,10 @@ def test_bootstrap_servers_in_consumer_config():
             consumer_config={"bootstrap.servers": ""},
         )
 
-        assert (
-            "do not specify 'bootstrap.servers' in consumer_config dictionary, "
-            "use only the 'bootstrap_servers' parameter" in excinfo.value
-        )
+    assert (
+        "do not specify 'bootstrap.servers' in consumer_config dictionary, "
+        "use only the 'bootstrap_servers' parameter" in str(excinfo)
+    )
 
 
 def test_bootstrap_servers_not_list():
@@ -56,10 +56,10 @@ def test_bootstrap_servers_not_list():
             group_id="abc",
             consumer_config={},
         )
-        assert (
-            "parameter `bootstrap_servers` must be a sequence of str, not str"
-            in excinfo.value
-        )
+    assert (
+        "parameter `bootstrap_servers` must be a sequence of str, not str"
+        in str(excinfo)
+    )
 
 
 def test_bad_consumer_config():
@@ -74,10 +74,10 @@ def test_bad_consumer_config():
                 "group.id": "raise an exception!",
             },
         )
-        assert (
-            "do not specify 'group.id' in consumer_config, use only the 'group_id' argument"
-            in excinfo.value
-        )
+    assert (
+        "do not specify 'group.id' in consumer_config, use only the 'group_id' parameter"
+        in str(excinfo)
+    )
 
 
 def test_redact_password_from_str():

--- a/bluesky_kafka/tests/test_basic_consumer.py
+++ b/bluesky_kafka/tests/test_basic_consumer.py
@@ -7,8 +7,8 @@ from bluesky_kafka.consume import BasicConsumer
     "bootstrap_servers, consumer_config_bootstrap_servers",
     [
         ([], ""),
-        (["1.2.3.4:9092"], "1.2.3.4:9092"),
-        (["1.2.3.4:9092", "localhost:9092"], "1.2.3.4:9092,localhost:9092"),
+        (["localhost:9092"], "localhost:9092"),
+        (["localhost:9091", "localhost:9092"], "localhost:9091,localhost:9092"),
     ],
 )
 def test_bootstrap_servers(bootstrap_servers, consumer_config_bootstrap_servers):
@@ -44,7 +44,7 @@ def test_bootstrap_servers_in_consumer_config():
 
     assert (
         "do not specify 'bootstrap.servers' in consumer_config dictionary, "
-        "use only the 'bootstrap_servers' parameter" in str(excinfo)
+        "use only the 'bootstrap_servers' parameter" in str(excinfo.value)
     )
 
 
@@ -52,13 +52,12 @@ def test_bootstrap_servers_not_list():
     with pytest.raises(TypeError) as excinfo:
         BasicConsumer(
             topics=["abc"],
-            bootstrap_servers="1.2.3.4:9092",
+            bootstrap_servers="localhost:9092",
             group_id="abc",
             consumer_config={},
         )
-    assert (
-        "parameter `bootstrap_servers` must be a sequence of str, not str"
-        in str(excinfo)
+    assert "parameter `bootstrap_servers` must be a sequence of str, not str" in str(
+        excinfo.value
     )
 
 
@@ -66,17 +65,15 @@ def test_bad_consumer_config():
     with pytest.raises(ValueError) as excinfo:
         BasicConsumer(
             topics=["abc"],
-            bootstrap_servers=["1.2.3.4:9092"],
+            bootstrap_servers=["localhost:9092"],
             group_id="abc",
             consumer_config={
-                "bootstrap.servers": "5.6.7.8:9092",
-                "auto.offset.reset": "latest",
                 "group.id": "raise an exception!",
             },
         )
     assert (
         "do not specify 'group.id' in consumer_config, use only the 'group_id' parameter"
-        in str(excinfo)
+        in str(excinfo.value)
     )
 
 
@@ -84,7 +81,7 @@ def test_redact_password_from_str():
     basic_consumer = BasicConsumer(
         topics=["abc"],
         bootstrap_servers=["localhost:9091", "localhost:9092"],
-        group_id="abc",
+        group_id="def",
         consumer_config={
             "sasl.password": "PASSWORD",
         },
@@ -94,8 +91,8 @@ def test_redact_password_from_str():
         "<class 'bluesky_kafka.consume.BasicConsumer'>("
         "topics=['abc'], "
         "consumer_config={"
-            "'sasl.password': '****', "
-            "'group.id': 'abc', "
-            "'bootstrap.servers': 'localhost:9091,localhost:9092'}"
+        "'sasl.password': '****', "
+        "'group.id': 'def', "
+        "'bootstrap.servers': 'localhost:9091,localhost:9092'}"
         ")"
     )

--- a/bluesky_kafka/tests/test_basic_producer.py
+++ b/bluesky_kafka/tests/test_basic_producer.py
@@ -7,8 +7,8 @@ from bluesky_kafka.produce import BasicProducer
     "bootstrap_servers, producer_config, combined_bootstrap_servers",
     [
         ([], {}, ""),
-        (["1.2.3.4:9092"], {}, "1.2.3.4:9092"),
-        (["1.2.3.4:9092", "localhost:9092"], {}, "1.2.3.4:9092,localhost:9092"),
+        (["localhost:9092"], {}, "localhost:9092"),
+        (["localhost:9091", "localhost:9092"], {}, "localhost:9091,localhost:9092"),
     ],
 )
 def test_bootstrap_servers(
@@ -47,7 +47,7 @@ def test_bootstrap_servers_in_producer_config():
 
     assert (
         "do not specify 'bootstrap.servers' in producer_config dictionary, "
-        "use only the 'bootstrap_servers' parameter" in str(excinfo)
+        "use only the 'bootstrap_servers' parameter" in str(excinfo.value)
     )
 
 
@@ -62,9 +62,8 @@ def test_bad_bootstrap_servers():
                 "bootstrap.servers": "localhost:9092",
             },
         )
-    assert (
-        "parameter `bootstrap_servers` must be a sequence of str, not str"
-        in str(excinfo)
+    assert "parameter `bootstrap_servers` must be a sequence of str, not str" in str(
+        excinfo.value
     )
 
 

--- a/bluesky_kafka/tests/test_basic_producer.py
+++ b/bluesky_kafka/tests/test_basic_producer.py
@@ -45,10 +45,10 @@ def test_bootstrap_servers_in_producer_config():
             producer_config={"bootstrap.servers": ""},
         )
 
-        assert (
-            "do not specify 'bootstrap.servers' in producer_config dictionary, "
-            "use only the 'bootstrap_servers' parameter" in excinfo.value
-        )
+    assert (
+        "do not specify 'bootstrap.servers' in producer_config dictionary, "
+        "use only the 'bootstrap_servers' parameter" in str(excinfo)
+    )
 
 
 def test_bad_bootstrap_servers():
@@ -62,10 +62,10 @@ def test_bad_bootstrap_servers():
                 "bootstrap.servers": "localhost:9092",
             },
         )
-        assert (
-            "parameter `bootstrap_servers` must be a sequence of str, not str"
-            in excinfo.value
-        )
+    assert (
+        "parameter `bootstrap_servers` must be a sequence of str, not str"
+        in str(excinfo)
+    )
 
 
 def test_redact_password_from_str_output():

--- a/bluesky_kafka/tests/test_bluesky_consumer.py
+++ b/bluesky_kafka/tests/test_bluesky_consumer.py
@@ -11,24 +11,24 @@ def test_consumer_config():
     test_topic = "test.consumer.config"
     bluesky_consumer = BlueskyConsumer(
         topics=[test_topic],
-        bootstrap_servers="1.2.3.4:9092",
+        bootstrap_servers="localhost:9091",
         group_id="abc",
         consumer_config={
-            "bootstrap.servers": "5.6.7.8:9092",
+            "bootstrap.servers": "localhost:9092",
             "auto.offset.reset": "latest",
         },
     )
 
     assert (
         bluesky_consumer._consumer_config["bootstrap.servers"]
-        == "1.2.3.4:9092,5.6.7.8:9092"
+        == "localhost:9091,localhost:9092"
     )
 
 
 def test_redact_password_from_str_output():
     bluesky_consumer = BlueskyConsumer(
         topics=["test.redact.password"],
-        bootstrap_servers="1.2.3.4:9092",
+        bootstrap_servers="localhost:9092",
         group_id="test-redact-password-group",
         consumer_config={
             "sasl.password": "PASSWORD",
@@ -46,15 +46,13 @@ def test_bad_consumer_config():
     with pytest.raises(ValueError) as excinfo:
         BlueskyConsumer(
             topics=[test_topic],
-            bootstrap_servers="1.2.3.4:9092",
+            bootstrap_servers="localhost:9092",
             group_id="test-bad-consumer_config",
             consumer_config={
-                "bootstrap.servers": "5.6.7.8:9092",
-                "auto.offset.reset": "latest",
                 "group.id": "raise an exception!",
             },
         )
     assert (
         "do not specify 'group.id' in consumer_config, use only the 'group_id' parameter"
-        in str(excinfo)
+        in str(excinfo.value)
     )

--- a/bluesky_kafka/tests/test_bluesky_consumer.py
+++ b/bluesky_kafka/tests/test_bluesky_consumer.py
@@ -54,7 +54,7 @@ def test_bad_consumer_config():
                 "group.id": "raise an exception!",
             },
         )
-        assert (
-            "do not specify 'group.id' in consumer_config, use only the 'group_id' argument"
-            in excinfo.value
-        )
+    assert (
+        "do not specify 'group.id' in consumer_config, use only the 'group_id' parameter"
+        in str(excinfo)
+    )

--- a/bluesky_kafka/tests/test_queue_thread.py
+++ b/bluesky_kafka/tests/test_queue_thread.py
@@ -226,7 +226,7 @@ def test_publisher_with_no_broker(RE, hw):
         build_kafka_publisher_queue_and_thread(
             topic=beamline_name,
             # specify a bootstrap server that does not exist
-            bootstrap_servers="100.100.100.100:9092",
+            bootstrap_servers="localhost:9999",
             producer_config={},
             publisher_queue_timeout=1,
         )


### PR DESCRIPTION
This PR fixes several cases in the tests in which assertions were made inside `pytest.raises` blocks but were never checked. This is because the assertions were made at a point in the test that was not executed due to the expected exception being raised. De-denting the assertions to be outside the `pytest.raises` block solved the problem.

Thanks to @mrakitin for finding these errors!