### PR TITLE
Resolve issues caused by :latest versions of Kafka and Zookeeper

### DIFF
--- a/scripts/bitnami-kafka-docker-compose.yml
+++ b/scripts/bitnami-kafka-docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3"
 services:
   zookeeper:
-    image: 'docker.io/bitnami/zookeeper:latest'
+    image: 'docker.io/bitnami/zookeeper:3.8'
     ports:
       - '2181:2181'
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: 'docker.io/bitnami/kafka:latest'
+    image: 'docker.io/bitnami/kafka:2.8'
     ports:
       - '9092:9092'
     environment:


### PR DESCRIPTION
New versions of Kakfa do not use Zookeeper by default. Now pinning the Kafka and Zookeeper versions so this configuration will continue to work as it has in the past.