### PR TITLE
Dynamic EventPage Rechunking

### DIFF
--- a/bluesky_kafka/__init__.py
+++ b/bluesky_kafka/__init__.py
@@ -152,6 +152,8 @@ class Publisher(BasicProducer):
             if KErr.code() == KafkaError.MSG_SIZE_TOO_LARGE:
                 if name == "event_page":
                     page_len = len(doc['seq_num'])
+                    if page_len == 1:
+                        raise
                     new_event_list = rechunk_event_pages([doc], (page_len + 1)//2)
                     for event in new_event_list:
                         self.__call__(name, event)

--- a/bluesky_kafka/__init__.py
+++ b/bluesky_kafka/__init__.py
@@ -9,6 +9,10 @@ from bluesky_kafka.produce import BasicProducer
 from bluesky.run_engine import Dispatcher, DocumentNames
 from suitcase import mongo_normalized
 
+from confluent_kafka import KafkaError, KafkaException
+
+from event_model import rechunk_event_pages
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]
@@ -141,7 +145,18 @@ class Publisher(BasicProducer):
             event-model document dictionary
 
         """
-        self.produce(message=(name, doc))
+        try:
+            self.produce(message=(name, doc))
+        except KafkaException as e:
+            KErr = e.args[0]
+            if KErr.code() == KafkaError.MSG_SIZE_TOO_LARGE:
+                if name == "event_page":
+                    page_len = len(doc['seq_num'])
+                    new_event_list = rechunk_event_pages([doc], (page_len + 1)//2)
+                    for event in new_event_list:
+                        self.__call__(name, event)
+            else:
+                raise e
         if self._flush_on_stop_doc and name == "stop":
             self.flush()
 


### PR DESCRIPTION
## Summary
Added try/except to Publisher to handle case where EventPages are too large, and dynamically re-chunk them.

## Motivation
When flyscanning, we can produce quite large EventPages of data that cause the Kafka producer to choke. Fortunately, an EventPage can be re-chunked quite easily (once https://github.com/bluesky/event-model/pull/297 is merged), so we should take advantage of this to produce documents that Kafka can handle.

## Details
I have added a try/except to the Publisher to catch the KafkaException indicating that a message is too large. If the message is too large, and the document was an EventPage, we should try re-chunking the document to half its size, and re-sending.

I have made this process recursive, so that the page size will be halved until the messages are small enough. Hopefully this only needs to happen once or twice, but with fly-scans, quite large EventPages can be generated.

## Testing

I have tested this by publishing quite large test pages, which successfully publish. All existing tests pass. Possibly more tests could be implemented.